### PR TITLE
Alteração para compatibilidade com ruby 2.4.0 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,7 @@ gem 'simplecov', '~> 0.7.1', group: :test, require: nil
 # A Ruby implementation of the Coveralls API.
 gem 'coveralls', require: false
 
+gem 'ruby-version', '~> 0.4.3'
+
 # Specify your gem's dependencies in cpf_utils.gemspec
 gemspec

--- a/lib/cpf_utils/cpf.rb
+++ b/lib/cpf_utils/cpf.rb
@@ -8,11 +8,21 @@ module CpfUtils
     def initialize(numbers)
       if numbers.is_a? String
         numbers = numbers.split('')
-      elsif numbers.is_a? Fixnum
-        numbers = numbers.to_s.split('')
+      elsif Ruby::Version < '2.4.0'
+        if numbers.is_a? Fixnum
+          numbers = split_number(numbers)
+        end
+      elsif Ruby::Version >= '2.4.0'
+        if numbers.is_a? Integer
+          numbers = split_number(numbers)
+        end
       end
 
       @numbers = numbers
+    end
+
+    def split_number (numbers)
+      numbers.to_s.split('')
     end
 
     # Gera o CPF propriamente dito


### PR DESCRIPTION

Na versão 2.4.0 do ruby o Fixnum/Bignum (deprecated) está sendo descontinuado em favor do Integer. 

Tal alteração não quebra compatibilidade com as versões anteriores.

fonte: https://bugs.ruby-lang.org/issues/12005